### PR TITLE
Fix for #642, missing clustering option in split_tm

### DIFF
--- a/R/split_tm.R
+++ b/R/split_tm.R
@@ -22,7 +22,7 @@ get_i <- function(x, xname, i, n, oid) {
 		if (ncol(x)>=i) x[oid,i] else x[oid,1]
 	} else if(is.list(x)) {
 		ncx <- nchar(xname)
-		if (xname %in% c("varnames", "idnames")  ||  substr(xname, ncx-11, ncx)=="popup.format") {
+		if (xname %in% c("varnames", "idnames", "clustering")  ||  substr(xname, ncx-11, ncx)=="popup.format") {
 			x
 		} else if (substr(xname, ncx-4, ncx) ==".misc") {
 			# these are lists themselves


### PR DESCRIPTION
Added "clustering" keyword to the function get_i referenced in split_tm, which before was dropping the previous clustering options and replacing with first value in list rather than including the entire list itself

Fixes #642 