### PR TITLE
Fix for #660 and #441

### DIFF
--- a/R/view_add_leaflet_titles.R
+++ b/R/view_add_leaflet_titles.R
@@ -6,7 +6,7 @@ view_add_leaflet_titles <- function(lf) {
 			if (title!="") {
 				l$children[[1]] <- l$children[[1]] %>% htmlwidgets::onRender(paste("
 					function(el, x) {
-						var tldiv = document.getElementsByClassName(\"leaflet-top leaflet-left\")[",i,"];
+						var tldiv = el.getElementsByClassName(\"leaflet-top leaflet-left\")[0];
 						var titlediv = document.createElement('div');
 						titlediv.className = \"info legend leaflet-control\";
 						titlediv.innerHTML = \"<b>", title, "</b>\";
@@ -21,7 +21,7 @@ view_add_leaflet_titles <- function(lf) {
 		if (title!="") {
 			lf <- lf %>% htmlwidgets::onRender(paste("
 						function(el, x) {
-							var tldiv = document.getElementsByClassName(\"leaflet-top leaflet-left\")[0];
+							var tldiv = el.getElementsByClassName(\"leaflet-top leaflet-left\")[0];
 							var titlediv = document.createElement('div');
 							titlediv.className = \"info legend leaflet-control\";
 							titlediv.innerHTML = \"<b>", title, "</b>\";


### PR DESCRIPTION
This changes view_add_leaflet_titles to use `el.getElementsByClassName` rather than `document.getElementsByClassName`, so we always work within the current leaflet widget. This fixes the issue in #660 and #441 where leaflet titles all float to the top

Without the fix, all the title would go onto the first leaflet widget (code to make the maps is below):
![image](https://user-images.githubusercontent.com/69762060/201217869-83620b4d-adb5-4cea-a895-0a124ba6d758.png)

![image](https://user-images.githubusercontent.com/69762060/201217826-1e09d9de-74df-412d-a5b2-bea13b16e614.png)

With the fix, each widget gets one title:
![image](https://user-images.githubusercontent.com/69762060/201217427-f48c18ec-a0d1-4144-b0bb-9fbdc39c52e6.png)

![image](https://user-images.githubusercontent.com/69762060/201217690-45b05e0c-e424-4e67-88b2-0b79ebf0df5b.png)

Code for maps:
```
library(sf)    
library(tmap)
library(dplyr)


tmap::tmap_mode('view') 
sf::sf_use_s2(use_s2 = FALSE)

data("NLD_prov")

tm_shape(NLD_prov[1:6, ]) +
    tm_polygons("population") +
	tm_layout(title = "Population")
	
tm_shape(NLD_prov[1:6, ]) +
	tm_polygons("pop_0_14", palette = "Blues") +
	tm_layout(title = "Population Under 14")
```