### PR TITLE
Fix typo: pallete should be palette

### DIFF
--- a/vignettes/tmap-getstarted.Rmd
+++ b/vignettes/tmap-getstarted.Rmd
@@ -213,7 +213,7 @@ Maps can also be made with one function call.
 This function is `qtm`:
 
 ```{r}
-qtm(World, fill = "HPI", fill.pallete = "RdYlGn")
+qtm(World, fill = "HPI", fill.palette = "RdYlGn")
 ```
 
 ### Tips 'n Tricks


### PR DESCRIPTION
The `qtm` example uses `fill.palette = "RdYlGn"` but the correct code is `fill.palette = "RdYlGn"`

The corresponding image uses the default color palette, indicating that the specified palette is not used. The code does not provide any error messages when run with the typo which may be a bug.