### PR TITLE
Update v3 pkgdown workflow.

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |
@@ -24,7 +24,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -43,7 +43,7 @@ jobs:
           install.packages("remotes")
           remotes::install_dev("tmaptools")
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_dev("pkgdown")
+          install.packages("pkgdown")
         shell: Rscript {0}
 
       - name: Install package


### PR DESCRIPTION
To have any chance of deploying tmap v3.3-4 docs, these should help.

But maybe a separate workflow would be required to host v3 docs to a different web address.

Maybe modifications in README would be required to point users to v4