### PR TITLE
Improve popup.vars error message

### DIFF
--- a/R/step1_helper_facets.R
+++ b/R/step1_helper_facets.R
@@ -169,8 +169,7 @@ step1_rearrange_facets = function(tmo, o) {
 				popup.format = process_label_format(popup.format, o$label.format)
 				
 				if (!all(popup.vars %in% smeta$vars)) {
-					# TODO add a more informative message that says which variables are incorrect.
-					stop("Incorrrect popup.vars specification", call. = FALSE)
+					rlang::arg_match(popup.vars, values = smeta$vars, multiple = TRUE)
 				}
 				if (length(popup.vars)) add_used_vars(popup.vars)
 


### PR DESCRIPTION
Example

```r
# before
NLD_prov |> 
	tm_shape() +
	tm_polygons(fill = "pop_25_44", popup.vars = c("pop_45_64", "origin_native2"))
#> Incorrect popup.vars specification.
# Now
NLD_prov |> 
	tm_shape() +
	tm_polygons(fill = "pop_25_44", popup.vars = c("pop_45_64", "origin_native2"))
#> ! `popup.vars` must be one of "code", "name", "population",
#>  "pop_men", "pop_women", "pop_0_14", "pop_15_24", "pop_25_44",
#> "pop_45_64", "pop_65plus", "origin_native", "origin_west", or
#>   "origin_non_west", not "origin_native2".
ℹ Did you mean "origin_native"?
```