### PR TITLE
cols4all is released

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,8 +62,6 @@ Suggests:
     tidyr
 VignetteBuilder: 
     knitr
-Remotes: 
-    r-tmap/tmaptools
 Config/Needs/check: Nowosad/spDataLarge, lwgeom
 Config/Needs/coverage: Nowosad/spDataLarge, lwgeom
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Depends:
     R (>= 3.5.0)
 Imports:
     classInt (>= 0.4-3),
-    cols4all (>= 0.6-1),
+    cols4all (>= 0.7),
     data.table,
     grid,
     htmltools,
@@ -63,7 +63,6 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes: 
-    mtennekes/cols4all,
     r-tmap/tmaptools
 Config/Needs/check: Nowosad/spDataLarge, lwgeom
 Config/Needs/coverage: Nowosad/spDataLarge, lwgeom

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ In order to use the development version of `tmap`, it is recommended to use the 
 
 ```r
 # install.packages("remotes")
-install_github("r-tmap/tmaptools")
 install_github("r-tmap/tmap")
 
 # On Linux, with pak


### PR DESCRIPTION
I also assumed that CRAN tmaptools is fine?

In case there is stilla need to rely on any of the dev versions. `usethis::use_dev_package("mtennekes/cols4all")` should do the trick