### PR TITLE
prepend `remotes::` to clarify where function comes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Installation of **tmap** (version 4) is straightforward:
 
 ``` r
 # install.packages("remotes")
-install_github("r-tmap/tmap")
+remotes::install_github("r-tmap/tmap")
 
 # On Linux, with pak
 # install.packages("pak")


### PR DESCRIPTION
Small detail but clarifies and makes consistent.